### PR TITLE
Add new contracts strategy which injects arbitrary code segments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,6 @@ run:
 	docker-compose up	-d
 	docker-compose logs -f replayor
 
-initialize:
+init:
 	mkdir secret
 	openssl rand -hex 32 > secret/jwt

--- a/cmd/replayor/main.go
+++ b/cmd/replayor/main.go
@@ -47,6 +47,9 @@ func Main() cliapp.LifecycleAction {
 		}
 
 		c, err := clients.SetupClients(cfg, logger, ctx)
+		if err != nil {
+			return nil, err
+		}
 
 		// Benchmark stats
 		s, err := stats.NewStorage(logger, cfg)

--- a/packages/config/config.go
+++ b/packages/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -44,7 +43,7 @@ func valueOrNil(i *uint64) string {
 
 func LoadReplayorConfig(cliCtx *cli.Context, l log.Logger) (ReplayorConfig, error) {
 	jwtFile := cliCtx.String(EngineApiSecret.Name)
-	jwtBytes, err := ioutil.ReadFile(jwtFile)
+	jwtBytes, err := os.ReadFile(jwtFile)
 	if err != nil {
 		return ReplayorConfig{}, err
 	}

--- a/packages/replayor/service.go
+++ b/packages/replayor/service.go
@@ -38,7 +38,7 @@ func (r *Service) Start(ctx context.Context) error {
 
 	currentBlock, err := r.clients.DestNode.BlockByNumber(ctx, nil)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	if r.cfg.BenchmarkStartBlock != 0 {
@@ -54,13 +54,13 @@ func (r *Service) Start(ctx context.Context) error {
 
 			walkUpToBlock.Run(cCtx)
 		} else {
-			panic("current block is greater than benchmark start block")
+			return errors.New("current block is greater than benchmark start block")
 		}
 	}
 
 	currentBlock, err = r.clients.DestNode.BlockByNumber(ctx, nil)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	if r.cfg.BenchmarkStartBlock != 0 && r.cfg.BenchmarkStartBlock != currentBlock.NumberU64() {
@@ -71,7 +71,7 @@ func (r *Service) Start(ctx context.Context) error {
 	r.log.Info("Starting benchmark", "start_block", currentBlock.NumberU64())
 	strategy := strategies.LoadStrategy(r.cfg, r.log, r.clients, currentBlock)
 	if strategy == nil {
-		panic(err)
+		return errors.New("invalid strategy")
 	}
 
 	benchmark := NewBenchmark(r.clients, r.cfg.RollupConfig, r.log, strategy, r.stats, currentBlock, uint64(r.cfg.BlockCount))

--- a/packages/strategies/contracts.go
+++ b/packages/strategies/contracts.go
@@ -1,0 +1,262 @@
+package strategies
+
+import (
+	"context"
+	"math/big"
+	"math/rand"
+
+	"github.com/danyalprout/replayor/packages/clients"
+	"github.com/danyalprout/replayor/packages/config"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type ContractStressTest struct {
+	startBlock *types.Block
+	buffer     []*types.Block
+	logger     log.Logger
+	cfg        config.ReplayorConfig
+	clients    clients.Clients
+}
+
+type ContractSegment struct {
+	bytes []byte
+	gas   uint64
+}
+
+var (
+	headSegment = ContractSegment{
+		bytes: []byte{
+			0x60, 0x80, // push1 0x80
+		},
+		gas: 3,
+	}
+
+	tailSegment = ContractSegment{
+		bytes: []byte{
+			0x50, // pop
+		},
+		gas: 2,
+	}
+
+	addSegment = ContractSegment{
+		bytes: []byte{
+			0x60, 0x40, // push1 0x40
+			0x01, // add
+		},
+		gas: 6,
+	}
+
+	subSegment = ContractSegment{
+		bytes: []byte{
+			0x60, 0x40, // push1 0x40
+			0x03, // sub
+		},
+		gas: 6,
+	}
+
+	mulSegment = ContractSegment{
+		bytes: []byte{
+			0x60, 0x02, // push1 0x40
+			0x02, // mul
+		},
+		gas: 8,
+	}
+
+	divSegment = ContractSegment{
+		bytes: []byte{
+			0x60, 0x02, // push1 0x40
+			0x04, // div
+		},
+		gas: 8,
+	}
+
+	sloadSegment = ContractSegment{
+		bytes: []byte{
+			0x54, // sload
+		},
+		gas: 2100,
+	}
+
+	sstoreSegment = ContractSegment{
+		bytes: []byte{
+			0x55, // sstore
+		},
+		gas: 5000,
+	}
+
+	bodySegments = []ContractSegment{
+		addSegment,
+		subSegment,
+		mulSegment,
+		divSegment,
+		sloadSegment,
+		sstoreSegment,
+	}
+)
+
+func NewContractStressTest(startBlock *types.Block, logger log.Logger, cfg config.ReplayorConfig, c clients.Clients) Strategy {
+	return &ContractStressTest{
+		startBlock: startBlock,
+		buffer:     []*types.Block{},
+		logger:     logger,
+		cfg:        cfg,
+		clients:    c,
+	}
+}
+
+func (s *ContractStressTest) modifyTransactions(input *types.Block, transactions types.Transactions) types.Transactions {
+	depositTxn := transactions[0]
+	l1Info, err := derive.L1BlockInfoFromBytes(s.cfg.RollupConfig, input.Time(), depositTxn.Data())
+	if err != nil {
+		panic(err)
+	}
+
+	result := types.Transactions{}
+
+	depositTxns := types.Transactions{}
+	userTxns := types.Transactions{}
+
+	for _, txn := range transactions {
+		if txn.IsDepositTx() {
+			depositTxns = append(depositTxns, txn)
+		} else {
+			userTxns = append(userTxns, txn)
+		}
+	}
+
+	currentBlockNum := input.NumberU64()
+
+	startBlockNum := s.startBlock.NumberU64()
+	// If first 10 blocks: Add one deposit transactions to send ETH to accounts
+	// Maybe if seqNum=0 (?)
+	if currentBlockNum < startBlockNum+11 {
+		i := currentBlockNum - startBlockNum - 1
+		addr := addresses[i]
+
+		// Add deposit transaction
+		var dep types.DepositTx
+
+		source := derive.UserDepositSource{
+			L1BlockHash: l1Info.BlockHash, // l1 block info
+			LogIndex:    10_000,           // hardcode to a very large number
+		}
+
+		val, ok := new(big.Int).SetString("100000000000000000000", 10)
+		if !ok {
+			panic(err)
+		}
+
+		dep.SourceHash = source.SourceHash()
+		dep.From = addr
+		dep.To = &addr
+		dep.Mint = val
+		dep.Value = val
+		dep.Gas = 21_000
+		dep.IsSystemTransaction = false
+
+		depositTxns = append(depositTxns, types.NewTx(&dep))
+
+		nonces[i] += 1
+	} else {
+		userTxns = append(userTxns, s.packItUp(input)...)
+	}
+
+	result = append(result, depositTxns...)
+	result = append(result, userTxns...)
+	return result
+}
+
+func (s *ContractStressTest) BlockReceived(ctx context.Context, input *types.Block) *BlockCreationParams {
+	gl := eth.Uint64Quantity(s.cfg.GasLimit)
+
+	txns := s.modifyTransactions(input, input.Transactions())
+
+	return &BlockCreationParams{
+		Number:       input.NumberU64(),
+		Transactions: txns,
+		GasLimit:     &gl,
+		Time:         eth.Uint64Quantity(input.Time()),
+		MixDigest:    eth.Bytes32(input.MixDigest()),
+		BeaconRoot:   input.BeaconRoot(),
+		validateInfo: input,
+	}
+}
+
+func (s *ContractStressTest) ValidateExecution(ctx context.Context, e *eth.ExecutionPayloadEnvelope, a BlockCreationParams) error {
+	// Skip: Validate block covers everything
+	return nil
+}
+
+func (s *ContractStressTest) ValidateBlock(ctx context.Context, e *eth.ExecutionPayloadEnvelope, a BlockCreationParams) error {
+	// Todo: Validate enough of the txns were included
+	return nil
+}
+
+func (s *ContractStressTest) packItUp(input *types.Block) types.Transactions {
+	gasInfo := input.Transactions()[len(input.Transactions())-1]
+
+	originTransactionUse := input.GasUsed()
+	targetUsage := input.GasLimit()
+
+	fillUp := targetUsage - originTransactionUse
+
+	result := types.Transactions{}
+
+	if fillUp <= 0 {
+		return result
+	}
+
+	fillUp = uint64(float64(fillUp) * 0.75)
+
+	for {
+		data, gasUsed := generateContractData()
+		if fillUp < gasUsed {
+			break
+		}
+
+		from := rand.Intn(length)
+
+		fillUp -= gasUsed
+
+		txn := types.NewTx(&types.DynamicFeeTx{
+			Nonce:     nonces[from],
+			Value:     big.NewInt(100),
+			Gas:       gasUsed,
+			GasTipCap: gasInfo.GasTipCap(),
+			GasFeeCap: gasInfo.GasFeeCap(),
+			Data:      data,
+		})
+
+		signer := types.NewLondonSigner(big.NewInt(8453))
+		signedTx, err := types.SignTx(txn, signer, privateKey[from])
+		if err != nil {
+			panic(err)
+		}
+
+		result = append(result, signedTx)
+		nonces[from]++
+	}
+
+	return result
+}
+
+func generateContractData() ([]byte, uint64) {
+	gasEstimate := uint64(21_000)
+	data := append([]byte{}, headSegment.bytes...)
+	gasEstimate += headSegment.gas + uint64(16*len(headSegment.bytes))
+
+	numBodySegments := rand.Intn(500)
+	for i := 0; i < numBodySegments; i++ {
+		segment := bodySegments[rand.Intn(len(bodySegments))]
+		data = append(data, segment.bytes...)
+		gasEstimate += segment.gas + uint64(16*len(segment.bytes))
+	}
+
+	data = append(data, tailSegment.bytes...)
+	gasEstimate += tailSegment.gas + uint64(16*len(tailSegment.bytes))
+
+	return data, gasEstimate
+}

--- a/packages/strategies/contracts.go
+++ b/packages/strategies/contracts.go
@@ -84,7 +84,7 @@ var (
 		bytes: []byte{
 			0x55, // sstore
 		},
-		gas: 5000,
+		gas: 22100,
 	}
 
 	bodySegments = []ContractSegment{
@@ -199,7 +199,7 @@ func (s *ContractStressTest) packItUp(input *types.Block) types.Transactions {
 	gasInfo := input.Transactions()[len(input.Transactions())-1]
 
 	originTransactionUse := input.GasUsed()
-	targetUsage := input.GasLimit()
+	targetUsage := input.GasLimit() / 6
 
 	fillUp := targetUsage - originTransactionUse
 
@@ -226,7 +226,7 @@ func (s *ContractStressTest) packItUp(input *types.Block) types.Transactions {
 			Value:     big.NewInt(100),
 			Gas:       gasUsed,
 			GasTipCap: gasInfo.GasTipCap(),
-			GasFeeCap: gasInfo.GasFeeCap(),
+			GasFeeCap: input.BaseFee().Mul(input.BaseFee(), big.NewInt(5)),
 			Data:      data,
 		})
 
@@ -258,5 +258,5 @@ func generateContractData() ([]byte, uint64) {
 	data = append(data, tailSegment.bytes...)
 	gasEstimate += tailSegment.gas + uint64(16*len(tailSegment.bytes))
 
-	return data, gasEstimate
+	return data, gasEstimate + 40_000
 }

--- a/packages/strategies/strategy.go
+++ b/packages/strategies/strategy.go
@@ -12,8 +12,9 @@ import (
 )
 
 const (
-	strategyTypeStress = "stress"
-	strategyTypeReplay = "replay"
+	strategyTypeStress    = "stress"
+	strategyTypeContracts = "contracts"
+	strategyTypeReplay    = "replay"
 )
 
 type BlockCreationParams struct {
@@ -36,6 +37,8 @@ func LoadStrategy(cfg config.ReplayorConfig, logger log.Logger, c clients.Client
 	switch cfg.Strategy {
 	case strategyTypeStress:
 		return NewStressTest(startBlock, logger, cfg, c)
+	case strategyTypeContracts:
+		return NewContractStressTest(startBlock, logger, cfg, c)
 	case strategyTypeReplay:
 		return &OneForOne{}
 	default:

--- a/packages/strategies/stress.go
+++ b/packages/strategies/stress.go
@@ -3,8 +3,8 @@ package strategies
 import (
 	"context"
 	"crypto/ecdsa"
-	"crypto/rand"
 	"math/big"
+	"math/rand"
 
 	"github.com/danyalprout/replayor/packages/clients"
 	"github.com/danyalprout/replayor/packages/config"
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	length = big.NewInt(10) // Generate number between 0 and 9
+	length = 10 // Generate number between 0 and 9
 
 	// Test private keys to make some fake txns from
 	privateKeyRaw = []string{
@@ -201,25 +201,18 @@ func (s *StressTest) packItUp(input *types.Block) types.Transactions {
 			break
 		}
 
-		from, err := rand.Int(rand.Reader, length)
-		if err != nil {
-			panic(err)
-		}
+		from := rand.Intn(length)
+		to := rand.Intn(length)
 
-		to, err := rand.Int(rand.Reader, length)
-		if err != nil {
-			panic(err)
-		}
-
-		if from.Cmp(to) == 0 {
+		if from == to {
 			continue
 		}
 
 		fillUp -= gasUsed
 
 		txn := types.NewTx(&types.DynamicFeeTx{
-			To:        &addresses[to.Int64()],
-			Nonce:     nonces[from.Int64()],
+			To:        &addresses[to],
+			Nonce:     nonces[from],
 			Value:     big.NewInt(100),
 			Gas:       gasUsed,
 			GasTipCap: gasInfo.GasTipCap(),
@@ -227,13 +220,13 @@ func (s *StressTest) packItUp(input *types.Block) types.Transactions {
 		})
 
 		signer := types.NewLondonSigner(big.NewInt(8453))
-		signedTx, err := types.SignTx(txn, signer, privateKey[from.Int64()])
+		signedTx, err := types.SignTx(txn, signer, privateKey[from])
 		if err != nil {
 			panic(err)
 		}
 
 		result = append(result, signedTx)
-		nonces[from.Int64()]++
+		nonces[from]++
 	}
 
 	return result


### PR DESCRIPTION
Introduces new "contracts" strategy which is similar to "stress" but performs arbitrary contract creation calls instead of ETH transfers. The contract data is composed of a series of segments which always results in an empty stack and memory, which should result in no actual contract being deployed.

While these contract segments are currently random, I would like to instead pass in known traits in order to intentionally stress test specific patterns of opcodes, such as long sequences of multiplications or sloads

* Improves some error handling code
* Updates the Makefile `init` command to be consistent with the readme
* Additional minor cleanup