### PR TITLE
Fix various concurrency and tracing issues

### DIFF
--- a/packages/replayor/benchmark.go
+++ b/packages/replayor/benchmark.go
@@ -66,7 +66,7 @@ func (r *Benchmark) loadBlocks(ctx context.Context) {
 		for i := uint64(0); i < concurrency; i++ {
 			blockNum := blockStartRange + i
 
-			go func(index uint64) {
+			go func(index, blockNum uint64) {
 				defer wg.Done()
 
 				block, err := r.getBlockFromSourceNode(ctx, blockNum)
@@ -81,7 +81,7 @@ func (r *Benchmark) loadBlocks(ctx context.Context) {
 				m.Lock()
 				results[index] = block
 				m.Unlock()
-			}(i)
+			}(i, blockNum)
 		}
 
 		wg.Wait()

--- a/packages/replayor/trace.go
+++ b/packages/replayor/trace.go
@@ -1,13 +1,89 @@
 package replayor
 
+import (
+	"context"
+
+	"github.com/danyalprout/replayor/packages/stats"
+	"github.com/ethereum-optimism/optimism/op-service/retry"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
 type TxTrace struct {
-	Gas        uint64 `json:"gas"`
-	Failed     bool   `json:"failed"`
-	StructLogs []struct {
-		Op      string `json:"op"`
-		Gas     uint64 `json:"gas"`
-		GasCost uint64 `json:"gasCost"`
-		Refund  uint64 `json:"refund"`
-		Depth   uint64 `json:"depth"`
-	} `json:"structLogs"`
+	Gas        uint64      `json:"gas"`
+	Failed     bool        `json:"failed"`
+	StructLogs []StructLog `json:"structLogs"`
+}
+
+type StructLog struct {
+	Op      string `json:"op"`
+	Gas     uint64 `json:"gas"`
+	GasCost uint64 `json:"gasCost"`
+	Refund  uint64 `json:"refund"`
+	Depth   uint64 `json:"depth"`
+}
+
+var tracerOptions = map[string]any{
+	"disableStack":   true,
+	"disableStorage": true,
+}
+
+func (r *Benchmark) computeTraceStats(ctx context.Context, s *stats.BlockCreationStats, receipts []*types.Receipt) {
+	s.OpCodes = make(map[string]stats.OpCodeStats)
+
+	for _, receipt := range receipts {
+		r.traceReceipt(ctx, receipt, s.OpCodes)
+	}
+}
+
+func (r *Benchmark) traceReceipt(ctx context.Context, receipt *types.Receipt, opCodes map[string]stats.OpCodeStats) {
+	txTrace, err := retry.Do(ctx, 10, retry.Exponential(), func() (*TxTrace, error) {
+		var txTrace TxTrace
+		err := r.clients.DestNode.Client().Call(&txTrace, "debug_traceTransaction", receipt.TxHash, tracerOptions)
+		if err != nil {
+			return nil, err
+		}
+		return &txTrace, nil
+	})
+	if err != nil {
+		r.log.Warn("unable to load tx trace", "err", err)
+		opCodes["UNKNOWN"] = stats.OpCodeStats{
+			Count: opCodes["UNKNOWN"].Count + 1,
+			Gas:   opCodes["UNKNOWN"].Gas + receipt.GasUsed,
+		}
+		return
+	}
+
+	var gasUsage uint64
+	for idx, log := range txTrace.StructLogs {
+		opGas := log.GasCost
+
+		var nextLog *StructLog
+		if idx < len(txTrace.StructLogs)-1 {
+			nextLog = &txTrace.StructLogs[idx+1]
+		}
+		if nextLog != nil && log.Depth < nextLog.Depth {
+			opGas = log.GasCost - nextLog.Gas
+		}
+
+		opCodes[log.Op] = stats.OpCodeStats{
+			Count: opCodes[log.Op].Count + 1,
+			Gas:   opCodes[log.Op].Gas + opGas,
+		}
+
+		gasUsage += opGas
+	}
+
+	gasRefund := txTrace.StructLogs[len(txTrace.StructLogs)-1].Refund
+
+	opCodes["REFUND"] = stats.OpCodeStats{
+		Count: opCodes["REFUND"].Count + 1,
+		Gas:   opCodes["REFUND"].Gas + gasRefund,
+	}
+
+	gasUsage -= gasRefund
+
+	opCodes["TRANSACTION"] = stats.OpCodeStats{
+		Count: opCodes["TRANSACTION"].Count + 1,
+		Gas:   opCodes["TRANSACTION"].Gas + receipt.GasUsed - gasUsage,
+	}
 }

--- a/packages/replayor/trace.go
+++ b/packages/replayor/trace.go
@@ -54,6 +54,7 @@ func (r *Benchmark) traceReceipt(ctx context.Context, receipt *types.Receipt, op
 	}
 
 	var gasUsage uint64
+	var gasRefund uint64
 	for idx, log := range txTrace.StructLogs {
 		opGas := log.GasCost
 
@@ -71,9 +72,8 @@ func (r *Benchmark) traceReceipt(ctx context.Context, receipt *types.Receipt, op
 		}
 
 		gasUsage += opGas
+		gasRefund = log.Refund
 	}
-
-	gasRefund := txTrace.StructLogs[len(txTrace.StructLogs)-1].Refund
 
 	opCodes["REFUND"] = stats.OpCodeStats{
 		Count: opCodes["REFUND"].Count + 1,

--- a/packages/replayor/trace.go
+++ b/packages/replayor/trace.go
@@ -62,8 +62,12 @@ func (r *Benchmark) traceReceipt(ctx context.Context, receipt *types.Receipt, op
 		if idx < len(txTrace.StructLogs)-1 {
 			nextLog = &txTrace.StructLogs[idx+1]
 		}
-		if nextLog != nil && log.Depth < nextLog.Depth {
-			opGas = log.GasCost - nextLog.Gas
+		if nextLog != nil {
+			if log.Depth < nextLog.Depth {
+				opGas = log.GasCost - nextLog.Gas
+			} else if log.Depth == nextLog.Depth {
+				opGas = log.Gas - nextLog.Gas
+			}
 		}
 
 		opCodes[log.Op] = stats.OpCodeStats{


### PR DESCRIPTION
This changeset fixes a variety of concurrency edge cases and race conditions, which are more pronounced during heavyweight benchmarking such as when opcode tracing is enabled.
* Wait up to 2 hours, in 10 second increments, for the engine API to finish syncing before executing the benchmarks. This appears to be necessary for certain Reth configurations, as the engine may perform some sync-related operations on startup.
* Lock around calls to `RecordBlockStats`
* Only stop processing blocks/stats after all stats have been recorded
* Refactor the opcode tracing to improve handling of static calls and gas refunds