### PR TITLE
fix: terminate process once it completes all the work

### DIFF
--- a/cmd/replayor/main.go
+++ b/cmd/replayor/main.go
@@ -58,6 +58,6 @@ func Main() cliapp.LifecycleAction {
 		}
 		statsRecorder := stats.NewStoredStats(s, logger)
 
-		return replayor.NewService(c, statsRecorder, cfg, logger), nil
+		return replayor.NewService(c, statsRecorder, cfg, logger, close), nil
 	}
 }

--- a/packages/replayor/service.go
+++ b/packages/replayor/service.go
@@ -24,14 +24,16 @@ type Service struct {
 	stats           stats.Stats
 	cfg             config.ReplayorConfig
 	log             log.Logger
+	close           context.CancelCauseFunc
 }
 
-func NewService(c clients.Clients, s stats.Stats, cfg config.ReplayorConfig, l log.Logger) *Service {
+func NewService(c clients.Clients, s stats.Stats, cfg config.ReplayorConfig, l log.Logger, close context.CancelCauseFunc) *Service {
 	return &Service{
 		clients: c,
 		stats:   s,
 		cfg:     cfg,
 		log:     l,
+		close:   close,
 	}
 }
 
@@ -98,6 +100,8 @@ func (r *Service) Start(ctx context.Context) error {
 	benchmark := NewBenchmark(r.clients, r.cfg.RollupConfig, r.log, strategy, r.stats, currentBlock, uint64(r.cfg.BlockCount), r.cfg.BenchmarkOpcodes, r.cfg.ComputeStorageDiffs)
 	benchmark.Run(cCtx)
 
+	// shutdown the whole application
+	r.close(nil)
 	return nil
 }
 


### PR DESCRIPTION
With this PR, `replayor` gracefully shutdown once it completes all the work.

Previously the process never terminates until you hit `ctrl + c`. I found it better to terminate the process once it's done working instead of leaving the process running but doing nothing.

NOTE: not a super expert in Go, this works btw.

@danyalprout 