### PR TITLE
fix: don't hard code fee recipient and withdrawals

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ replace github.com/ethereum/go-ethereum v1.14.8 => github.com/ethereum-optimism/
 
 require (
 	github.com/ethereum-optimism/optimism v1.9.3-0.20240924125057-0fee34b645ca
-	github.com/ethereum-optimism/optimism/op-bindings v0.10.14
 	github.com/ethereum/go-ethereum v1.14.8
 	github.com/minio/minio-go/v7 v7.0.76
 	github.com/urfave/cli/v2 v2.27.4

--- a/go.sum
+++ b/go.sum
@@ -157,8 +157,6 @@ github.com/ethereum-optimism/op-geth v1.101408.0-rc.4.0.20240827042333-110c433a2
 github.com/ethereum-optimism/op-geth v1.101408.0-rc.4.0.20240827042333-110c433a2469/go.mod h1:Mk8AhvlqFbjI9oW2ymThSSoqc6kiEH0/tCmHGMEu6ac=
 github.com/ethereum-optimism/optimism v1.9.3-0.20240924125057-0fee34b645ca h1:KT9pWgX0EXRzVNKLCoYolQxpOSpRYf4E0N9uKMJmeqU=
 github.com/ethereum-optimism/optimism v1.9.3-0.20240924125057-0fee34b645ca/go.mod h1:hBy5DjWde0XP/berSXl16EMsKS2D2WDQ7us/yzd4PG0=
-github.com/ethereum-optimism/optimism/op-bindings v0.10.14 h1:SMMnMdNb1QIhJDyvk7QMUv+crAP4UHHoSYBOASBDIjM=
-github.com/ethereum-optimism/optimism/op-bindings v0.10.14/go.mod h1:9ZSUq/rjlzp3uYyBN4sZmhTc3oZgDVqJ4wrUja7vj6c=
 github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240910145426-b3905c89e8ac h1:hCIrLuOPV3FJfMDvXeOhCC3uQNvFoMIIlkT2mN2cfeg=
 github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240910145426-b3905c89e8ac/go.mod h1:XaVXL9jg8BcyOeugECgIUGa9Y3DjYJj71RHmb5qon6M=
 github.com/ethereum/c-kzg-4844 v1.0.0 h1:0X1LBXxaEtYD9xsyj9B9ctQEZIpnvVDeoBx8aHEwTNA=

--- a/packages/replayor/benchmark.go
+++ b/packages/replayor/benchmark.go
@@ -10,7 +10,6 @@ import (
 	"github.com/danyalprout/replayor/packages/clients"
 	"github.com/danyalprout/replayor/packages/stats"
 	"github.com/danyalprout/replayor/packages/strategies"
-	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
@@ -123,7 +122,7 @@ func (r *Benchmark) addBlock(ctx context.Context, currentBlock strategies.BlockC
 	attrs := &eth.PayloadAttributes{
 		Timestamp:             currentBlock.Time,
 		NoTxPool:              true,
-		SuggestedFeeRecipient: predeploys.SequencerFeeVaultAddr,
+		SuggestedFeeRecipient: currentBlock.FeeRecipient,
 		Transactions:          txnData,
 		GasLimit:              currentBlock.GasLimit,
 		PrevRandao:            currentBlock.MixDigest,

--- a/packages/replayor/benchmark.go
+++ b/packages/replayor/benchmark.go
@@ -127,10 +127,7 @@ func (r *Benchmark) addBlock(ctx context.Context, currentBlock strategies.BlockC
 		GasLimit:              currentBlock.GasLimit,
 		PrevRandao:            currentBlock.MixDigest,
 		ParentBeaconBlockRoot: currentBlock.BeaconRoot,
-	}
-
-	if r.rollupCfg.IsCanyon(uint64(currentBlock.Time)) {
-		attrs.Withdrawals = &types.Withdrawals{}
+		Withdrawals:           &currentBlock.Withdrawals,
 	}
 
 	startTime := time.Now()

--- a/packages/strategies/replay.go
+++ b/packages/strategies/replay.go
@@ -21,6 +21,7 @@ func blockToCreationParams(input *types.Block) BlockCreationParams {
 		Time:         eth.Uint64Quantity(input.Time()),
 		MixDigest:    eth.Bytes32(input.MixDigest()),
 		BeaconRoot:   input.BeaconRoot(),
+		FeeRecipient: input.Coinbase(),
 		validateInfo: input.Hash(),
 	}
 }

--- a/packages/strategies/replay.go
+++ b/packages/strategies/replay.go
@@ -22,6 +22,7 @@ func blockToCreationParams(input *types.Block) BlockCreationParams {
 		MixDigest:    eth.Bytes32(input.MixDigest()),
 		BeaconRoot:   input.BeaconRoot(),
 		FeeRecipient: input.Coinbase(),
+		Withdrawals:  input.Withdrawals(),
 		validateInfo: input.Hash(),
 	}
 }

--- a/packages/strategies/strategy.go
+++ b/packages/strategies/strategy.go
@@ -23,6 +23,7 @@ type BlockCreationParams struct {
 	Time         eth.Uint64Quantity
 	MixDigest    eth.Bytes32
 	BeaconRoot   *common.Hash
+	FeeRecipient common.Address
 	validateInfo interface{}
 }
 

--- a/packages/strategies/strategy.go
+++ b/packages/strategies/strategy.go
@@ -24,6 +24,7 @@ type BlockCreationParams struct {
 	MixDigest    eth.Bytes32
 	BeaconRoot   *common.Hash
 	FeeRecipient common.Address
+	Withdrawals  types.Withdrawals
 	validateInfo interface{}
 }
 


### PR DESCRIPTION
This PR generalizes a bit the way how `replayor` handles withdrawals and the fee recipient.

Previous to this PR, the fee recipient is always hard coded to be the one of OP Stack chains, which is fine but I think it's better to take it directly from the block as we have this information inside the block. This also opens up the possibility to do some backtesting on eth mainnet (by tweaking its normal behaviour of course).

Same thing applies for withdrawals: we can take them directly from the block instead of hard coding them to empty.

@danyalprout 