### PR TITLE
Updates based on optimism benchmark testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ geth-data/
 secret/
 results/
 reth-data/
+*.crt

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,3 +13,5 @@ WORKDIR /app
 FROM golang:1.21
 
 COPY --from=builder /app/bin/replayor /app/bin/replayor
+
+CMD ["/app/bin/replayor"]

--- a/cmd/replayor/main.go
+++ b/cmd/replayor/main.go
@@ -60,7 +60,7 @@ func Main() cliapp.LifecycleAction {
 		}
 		logger.Info("storage setup complete")
 
-		statsRecorder := stats.NewStoredStats(s, logger)
+		statsRecorder := stats.NewStoredStats(s, logger, cfg.BenchmarkStartBlock)
 		logger.Info("stats recorder setup complete")
 
 		return replayor.NewService(c, statsRecorder, cfg, logger, close), nil

--- a/cmd/replayor/main.go
+++ b/cmd/replayor/main.go
@@ -45,18 +45,23 @@ func Main() cliapp.LifecycleAction {
 		if err != nil {
 			return nil, err
 		}
+		logger.Info("config setup complete")
 
 		c, err := clients.SetupClients(cfg, logger, ctx)
 		if err != nil {
 			return nil, err
 		}
+		logger.Info("client setup complete")
 
 		// Benchmark stats
 		s, err := stats.NewStorage(logger, cfg)
 		if err != nil {
 			return nil, err
 		}
+		logger.Info("storage setup complete")
+
 		statsRecorder := stats.NewStoredStats(s, logger)
+		logger.Info("stats recorder setup complete")
 
 		return replayor.NewService(c, statsRecorder, cfg, logger, close), nil
 	}

--- a/packages/clients/clients.go
+++ b/packages/clients/clients.go
@@ -21,6 +21,7 @@ type Clients struct {
 }
 
 func SetupClients(cfg config.ReplayorConfig, logger log.Logger, ctx context.Context) (Clients, error) {
+	logger.Info("dialing source node url", "url", cfg.SourceNodeUrl)
 	sourceNode, err := ethclient.Dial(cfg.SourceNodeUrl)
 	if err != nil {
 		return Clients{}, err
@@ -28,6 +29,7 @@ func SetupClients(cfg config.ReplayorConfig, logger log.Logger, ctx context.Cont
 
 	// Add some retries around connecting to the dest node as it starts up at the same time as the replayor
 	destNode, err := retry.Do(ctx, 120, retry.Fixed(time.Second), func() (*ethclient.Client, error) {
+		logger.Info("dialing destination node url", "url", cfg.ExecutionUrl)
 		d, e := ethclient.Dial(cfg.ExecutionUrl)
 		if e != nil {
 			logger.Info("waiting for geth (exec) to start")
@@ -35,7 +37,6 @@ func SetupClients(cfg config.ReplayorConfig, logger log.Logger, ctx context.Cont
 
 		return d, e
 	})
-
 	if err != nil {
 		return Clients{}, err
 	}
@@ -49,6 +50,7 @@ func SetupClients(cfg config.ReplayorConfig, logger log.Logger, ctx context.Cont
 
 	// Add some retries around connecting to the dest node as it starts up at the same time as the replayor
 	engineApi, err := retry.Do(ctx, 120, retry.Fixed(time.Second), func() (*sources.EngineAPIClient, error) {
+		logger.Info("dialing destination engine api url", "url", cfg.EngineApiUrl)
 		l2Node, err := client.NewRPC(ctx, logger, cfg.EngineApiUrl, opts...)
 		if err != nil {
 			logger.Info("waiting for geth (rpc) to start")
@@ -59,7 +61,6 @@ func SetupClients(cfg config.ReplayorConfig, logger log.Logger, ctx context.Cont
 
 		return engineApi, nil
 	})
-
 	if err != nil {
 		return Clients{}, err
 	}

--- a/packages/config/config.go
+++ b/packages/config/config.go
@@ -44,13 +44,12 @@ func valueOrNil(i *uint64) string {
 }
 
 func LoadReplayorConfig(cliCtx *cli.Context, l log.Logger) (ReplayorConfig, error) {
-	jwtFile := cliCtx.String(EngineApiSecret.Name)
-	jwtBytes, err := os.ReadFile(jwtFile)
-	if err != nil {
-		return ReplayorConfig{}, err
+	secret := cliCtx.String(EngineApiSecret.Name)
+	if secret == "" {
+		return ReplayorConfig{}, fmt.Errorf("must provide REPLAYOR_ENGINE_API_SECRET env var")
 	}
 
-	secret := common.HexToHash(strings.TrimSpace(string(jwtBytes)))
+	secretHash := common.HexToHash(strings.TrimSpace(secret))
 
 	chainId := cliCtx.String(ChainId.Name)
 	rollupCfgPath := cliCtx.String(RollupConfigPath.Name)
@@ -72,7 +71,7 @@ func LoadReplayorConfig(cliCtx *cli.Context, l log.Logger) (ReplayorConfig, erro
 	}
 
 	return ReplayorConfig{
-		EngineApiSecret:     secret,
+		EngineApiSecret:     secretHash,
 		SourceNodeUrl:       cliCtx.String(SourceNodeUrl.Name),
 		ChainId:             chainId,
 		RollupConfig:        rollupCfg,

--- a/packages/config/config.go
+++ b/packages/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"math/big"
 	"os"
 	"strings"
 
@@ -15,14 +16,14 @@ import (
 type ReplayorConfig struct {
 	EngineApiSecret     common.Hash
 	SourceNodeUrl       string
-	ChainId             string
+	ChainId             *big.Int
 	RollupConfig        *rollup.Config
 	EngineApiUrl        string
 	ExecutionUrl        string
 	Strategy            string
 	BlockCount          int
-	GasTarget           int
-	GasLimit            int
+	GasTarget           uint64
+	GasLimit            uint64
 	BenchmarkStartBlock uint64
 	BenchmarkOpcodes    bool
 	ComputeStorageDiffs bool
@@ -70,17 +71,23 @@ func LoadReplayorConfig(cliCtx *cli.Context, l log.Logger) (ReplayorConfig, erro
 		return ReplayorConfig{}, err
 	}
 
+	gasLimit := cliCtx.Uint64(GasLimit.Name)
+	gasTarget := cliCtx.Uint64(GasTarget.Name)
+	if gasTarget > gasLimit {
+		return ReplayorConfig{}, fmt.Errorf("cannot set gasTarget greater than gasLimit")
+	}
+
 	return ReplayorConfig{
 		EngineApiSecret:     secretHash,
 		SourceNodeUrl:       cliCtx.String(SourceNodeUrl.Name),
-		ChainId:             chainId,
+		ChainId:             rollupCfg.L2ChainID,
 		RollupConfig:        rollupCfg,
 		EngineApiUrl:        cliCtx.String(EngineApiUrl.Name),
 		ExecutionUrl:        cliCtx.String(ExecutionUrl.Name),
 		Strategy:            cliCtx.String(Strategy.Name),
 		BlockCount:          cliCtx.Int(BlockCount.Name),
-		GasTarget:           cliCtx.Int(GasTarget.Name),
-		GasLimit:            cliCtx.Int(GasLimit.Name),
+		GasTarget:           gasTarget,
+		GasLimit:            gasLimit,
 		BenchmarkStartBlock: cliCtx.Uint64(BenchmarkStartBlock.Name),
 		BenchmarkOpcodes:    cliCtx.Bool(BenchmarkOpcodes.Name),
 		ComputeStorageDiffs: cliCtx.Bool(ComputeStorageDiffs.Name),

--- a/packages/config/config.go
+++ b/packages/config/config.go
@@ -66,9 +66,12 @@ func LoadReplayorConfig(cliCtx *cli.Context, l log.Logger) (ReplayorConfig, erro
 
 	l.Info("activation", "canyon", valueOrNil(rollupCfg.CanyonTime), "delta", valueOrNil(rollupCfg.DeltaTime), "ecotone", valueOrNil(rollupCfg.EcotoneTime), "fjord", valueOrNil(rollupCfg.FjordTime))
 
-	hostname, err := os.Hostname()
-	if err != nil {
-		return ReplayorConfig{}, err
+	testName := cliCtx.String(TestName.Name)
+	if testName == "" {
+		testName, err = os.Hostname()
+		if err != nil {
+			return ReplayorConfig{}, err
+		}
 	}
 
 	gasLimit := cliCtx.Uint64(GasLimit.Name)
@@ -91,7 +94,7 @@ func LoadReplayorConfig(cliCtx *cli.Context, l log.Logger) (ReplayorConfig, erro
 		BenchmarkStartBlock: cliCtx.Uint64(BenchmarkStartBlock.Name),
 		BenchmarkOpcodes:    cliCtx.Bool(BenchmarkOpcodes.Name),
 		ComputeStorageDiffs: cliCtx.Bool(ComputeStorageDiffs.Name),
-		TestName:            hostname,
+		TestName:            testName + "_",
 		Bucket:              cliCtx.String(S3Bucket.Name),
 		StorageType:         cliCtx.String(StorageType.Name),
 		DiskPath:            cliCtx.String(DiskPath.Name),

--- a/packages/config/flags.go
+++ b/packages/config/flags.go
@@ -82,6 +82,12 @@ var (
 		Usage:   "whether to include storage diff metrics in the benchmark results",
 		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "COMPUTE_STORAGE_DIFFS"),
 	}
+	TestName = &cli.StringFlag{
+		Name:     "test-name",
+		Usage:    "test name used as prefix for output file",
+		Required: false,
+		EnvVars:  opservice.PrefixEnvVar(EnvVarPrefix, "TEST_NAME"),
+	}
 	S3Bucket = &cli.StringFlag{
 		Name:     "s3-bucket",
 		Usage:    "The S3 bucket to store results in",
@@ -104,7 +110,7 @@ var (
 
 func init() {
 	Flags = append(Flags, oplog.CLIFlags(EnvVarPrefix)...)
-	Flags = append(Flags, EngineApiSecret, SourceNodeUrl, ChainId, EngineApiUrl, ExecutionUrl, Strategy, BlockCount, GasTarget, GasLimit, S3Bucket, StorageType, DiskPath, BenchmarkStartBlock, BenchmarkOpcodes, ComputeStorageDiffs, RollupConfigPath)
+	Flags = append(Flags, EngineApiSecret, SourceNodeUrl, ChainId, EngineApiUrl, ExecutionUrl, Strategy, BlockCount, GasTarget, GasLimit, S3Bucket, StorageType, DiskPath, BenchmarkStartBlock, BenchmarkOpcodes, ComputeStorageDiffs, TestName, RollupConfigPath)
 }
 
 // Flags contains the list of configuration options available to the binary.

--- a/packages/config/flags.go
+++ b/packages/config/flags.go
@@ -11,7 +11,7 @@ const EnvVarPrefix = "REPLAYOR"
 var (
 	EngineApiSecret = &cli.StringFlag{
 		Name:     "engine-api-secret",
-		Usage:    "The path to the engine api secret",
+		Usage:    "Engine api secret",
 		Required: true,
 		EnvVars:  opservice.PrefixEnvVar(EnvVarPrefix, "ENGINE_API_SECRET"),
 	}

--- a/packages/replayor/service.go
+++ b/packages/replayor/service.go
@@ -38,6 +38,7 @@ func NewService(c clients.Clients, s stats.Stats, cfg config.ReplayorConfig, l l
 }
 
 func (r *Service) Start(ctx context.Context) error {
+	r.log.Info("starting replayor service")
 	cCtx, cancelFunc := context.WithCancel(ctx)
 	r.benchmarkCancel = cancelFunc
 
@@ -45,6 +46,7 @@ func (r *Service) Start(ctx context.Context) error {
 	if err != nil {
 		panic(err)
 	}
+	r.log.Info("retrieved current block number", "blockNum", currentBlock.Number())
 
 	retry.Do(ctx, 720, retry.Fixed(10*time.Second), func() (bool, error) {
 		result, err := r.clients.EngineApi.ForkchoiceUpdate(ctx, &eth.ForkchoiceState{

--- a/packages/replayor/service.go
+++ b/packages/replayor/service.go
@@ -70,6 +70,7 @@ func (r *Service) Start(ctx context.Context) error {
 				r.clients,
 				r.cfg.RollupConfig,
 				r.log,
+				// strategies.NewStressTest(currentBlock, r.log, r.cfg, r.clients),
 				&strategies.OneForOne{},
 				&stats.NoOpStats{},
 				currentBlock,
@@ -96,7 +97,7 @@ func (r *Service) Start(ctx context.Context) error {
 	r.log.Info("Starting benchmark", "start_block", currentBlock.NumberU64())
 	strategy := strategies.LoadStrategy(r.cfg, r.log, r.clients, currentBlock)
 	if strategy == nil {
-		panic("failed to load strategy")
+		panic("could not load strategy")
 	}
 
 	benchmark := NewBenchmark(r.clients, r.cfg.RollupConfig, r.log, strategy, r.stats, currentBlock, uint64(r.cfg.BlockCount), r.cfg.BenchmarkOpcodes, r.cfg.ComputeStorageDiffs)

--- a/packages/stats/disk.go
+++ b/packages/stats/disk.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/danyalprout/replayor/packages/config"
@@ -19,10 +20,10 @@ type DiskStorage struct {
 }
 
 func NewDiskStorage(l log.Logger, cfg config.ReplayorConfig) (*DiskStorage, error) {
-	dir := fmt.Sprintf("%s/%s/%s", cfg.DiskPath, cfg.TestName, cfg.TestDescription())
-	path := fmt.Sprintf("%s/%d", dir, time.Now().Unix())
+	dir := fmt.Sprintf("%s/%s", cfg.DiskPath, cfg.TestDescription())
+	path := fmt.Sprintf("%s/%s", dir, cfg.TestName+strconv.FormatInt(time.Now().Unix(), 10))
 
-	err := os.MkdirAll(dir, 0755)
+	err := os.MkdirAll(dir, 0o755)
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +41,7 @@ func (s *DiskStorage) Write(ctx context.Context, data []BlockCreationStats) erro
 		return errors.New("error encoding data")
 	}
 
-	err = os.WriteFile(s.path, b, 0644)
+	err = os.WriteFile(s.path, b, 0o644)
 	if err != nil {
 		s.log.Warn("error writing results", "name", s.path, "err", err)
 		return errors.New("error writing data")


### PR DESCRIPTION
Introducing some bug fixes and changes based on experience when using `replayor` for `op-geth` benchmark testing.